### PR TITLE
(SIMP-2936) Allow easy modification of /etc/shells

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 * Sat Mar 25 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.0
 - Provided the ability to simply add shells to /etc/shells
 - Removed all entries from /etc/securetty by default to match the latest
-  standard best practices
+  standard best practices. This removed ZSH.
 
 * Tue Feb 7 2017 Nick Miller <nick.miller@onyxpoint.com> - 0.0.1
 - Add useradd::passwd to manage passwd and related files

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Sat Mar 25 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.0
+- Provided the ability to simply add shells to /etc/shells
+- Removed all entries from /etc/securetty by default to match the latest
+  standard best practices
+
 * Tue Feb 7 2017 Nick Miller <nick.miller@onyxpoint.com> - 0.0.1
 - Add useradd::passwd to manage passwd and related files
 - Manages /etc/securetty and /etc/shells

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :test do
   gem 'hiera-puppet-helper'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
+  gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
@@ -24,7 +25,6 @@ group :development do
   gem 'travis-lint'
   gem 'travish'
   gem 'puppet-blacksmith'
-  gem 'puppet-strings'
   gem 'guard-rake'
   gem 'pry'
   gem 'pry-doc'
@@ -35,8 +35,11 @@ group :development do
 end
 
 group :system_tests do
-  # This patch is required to fix Beaker's broken `aio` handling
-  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-931-2.51.0'
+  # This patch is required to fix Beaker's broken `aio` handling and provide support for SuSE
+  # If you want to use 'bundle update --local', comment out this line and uncomment the next line
+  # If you do this, please remember not to check in that change.
+  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-978-2.51.0'
+  # gem 'beaker'
   gem 'beaker-rspec'
   gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,22 +19,39 @@
 #   If true, manage `/etc/default/nss`
 #
 # @param securetty
-#   List of ttys available to log into. Set to false to disable management.
+#   List of ttys available to log into
+#
+#   * Set to false to disable management
+#   * If the Array is empty (default) then root will not be able to log into
+#     any local device
+#   * If the string 'ANY_SHELL' is found in the Array, then the
+#     ``/etc/securetty`` file will be removed and root will be able to login
+#     via any device.
+#
+# @param shells_default
+#   List of shells that will appear on the system by default
+#
+#   * These have been set to the usual suspects and users should use the
+#     ``shells`` parameter to add to the list
 #
 # @param shells
-#   List of shells available to the user to set as default. Set to false to
-#   disable management.
+#   List of shells available to the user to set as default
+#
+#   * Set to false to disable management
+#   * Will be combined with ``shells_default`` in /etc/shells
 #
 class useradd (
-  Boolean $manage_etc_profile    = true,
-  Boolean $manage_libuser_conf   = true,
-  Boolean $manage_login_defs     = true,
-  Boolean $manage_nss            = true,
-  Boolean $manage_passwd_perms   = true,
-  Boolean $manage_sysconfig_init = true,
-  Boolean $manage_useradd        = true,
-  Variant[Boolean,Array[String]]               $securetty = [ 'console','tty1','tty2','tty3','tty4','tty5','tty6','ttyS0','ttyS1' ],
-  Variant[Boolean,Array[Stdlib::AbsolutePath]] $shells = [ '/bin/sh','/bin/zsh','/bin/bash','/sbin/nologin' ]
+  Boolean                                      $manage_etc_profile    = true,
+  Boolean                                      $manage_libuser_conf   = true,
+  Boolean                                      $manage_login_defs     = true,
+  Boolean                                      $manage_nss            = true,
+  Boolean                                      $manage_passwd_perms   = true,
+  Boolean                                      $manage_sysconfig_init = true,
+  Boolean                                      $manage_useradd        = true,
+  Variant[Boolean,Array[String]]               $securetty             = [],
+
+  Array[Stdlib::AbsolutePath]                  $shells_default        = [ '/bin/sh','/bin/bash','/sbin/nologin','/usr/bin/sh','/usr/bin/bash','/usr/sbin/nologin' ],
+  Variant[Boolean,Array[Stdlib::AbsolutePath]] $shells                = []
 ) {
 
   if $manage_etc_profile    { include '::useradd::etc_profile' }
@@ -46,7 +63,15 @@ class useradd (
   if $manage_useradd        { include '::useradd::useradd' }
 
   if $securetty {
+    if 'ANY_SHELL' in $securetty {
+      $_ensure_securetty = 'absent'
+    }
+    else {
+      $_ensure_securetty = 'file'
+    }
+
     file { '/etc/securetty':
+      ensure  => $_ensure_securetty,
       owner   => 'root',
       group   => 'root',
       mode    => '0400',
@@ -54,13 +79,12 @@ class useradd (
     }
   }
 
-  if $shells {
+  if $shells and !(empty($shells_default) and empty($shells)) {
     file { '/etc/shells':
       owner   => 'root',
       group   => 'root',
       mode    => '0644',
-      content => join($shells,"\n")
+      content => join(($shells_default + $shells),"\n")
     }
   }
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -49,8 +49,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": "4.6"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
-  ],
-  "data_provider": "hiera"
+  ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-useradd",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "author":  "SIMP Team",
   "summary": "A SIMP puppet module for managing settings regarding users and user creation",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,26 +8,55 @@ describe 'useradd' do
           facts
         end
 
-        context 'with default parameters' do
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_class('useradd') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('useradd') }
+
+        it { is_expected.to create_file('/etc/securetty').with_content(<<-EOF.gsub(/^\s+/,'').strip
+        EOF
+        ) }
+
+        it { is_expected.to create_file('/etc/shells').with_content(<<-EOF.gsub(/^\s+/,'').strip
+          /bin/sh
+          /bin/bash
+          /sbin/nologin
+          /usr/bin/sh
+          /usr/bin/bash
+          /usr/sbin/nologin
+        EOF
+        ) }
+
+        context 'when adding a securetty entry' do
+          let(:params){{
+            :securetty => ['console']
+          }}
+
           it { is_expected.to create_file('/etc/securetty').with_content(<<-EOF.gsub(/^\s+/,'').strip
             console
-            tty1
-            tty2
-            tty3
-            tty4
-            tty5
-            tty6
-            ttyS0
-            ttyS1
           EOF
           ) }
+        end
+
+        context 'when allowing from ANY_SHELL' do
+          let(:params){{
+            :securetty => ['console', 'ANY_SHELL']
+          }}
+
+          it { is_expected.to create_file('/etc/securetty').with_ensure('absent') }
+        end
+
+        context 'when adding a shell' do
+          let(:params){{
+            :shells => ['/bin/foo']
+          }}
+
           it { is_expected.to create_file('/etc/shells').with_content(<<-EOF.gsub(/^\s+/,'').strip
             /bin/sh
-            /bin/zsh
             /bin/bash
             /sbin/nologin
+            /usr/bin/sh
+            /usr/bin/bash
+            /usr/sbin/nologin
+            /bin/foo
           EOF
           ) }
         end
@@ -36,11 +65,11 @@ describe 'useradd' do
           let(:params) {{ :shells => false }}
           it { is_expected.not_to create_file('/etc/shells') }
         end
+
         context 'with securetty => false' do
           let(:params) {{ :securetty => false }}
           it { is_expected.not_to create_file('/etc/securetty') }
         end
-
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,13 +25,11 @@ end
 default_hiera_config =<<-EOM
 ---
 :backends:
-  - "rspec"
   - "yaml"
 :yaml:
   :datadir: "stub"
 :hierarchy:
   - "%{custom_hiera}"
-  - "%{spec_title}"
   - "%{module_name}"
   - "default"
 EOM
@@ -47,7 +45,7 @@ EOM
 # end
 #
 def set_environment(environment = :production)
-    RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
+  RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
 end
 
 # This can be used from inside your spec tests to load custom hieradata within
@@ -69,7 +67,7 @@ end
 #
 # Note: Any colons (:) are replaced with underscores (_) in the class name.
 def set_hieradata(hieradata)
-    RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
+  RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
 end
 
 if not File.directory?(File.join(fixture_path,'hieradata')) then
@@ -86,7 +84,7 @@ RSpec.configure do |c|
     :production => {
       #:fqdn           => 'production.rspec.test.localdomain',
       :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
-      :concat_basedir => '/tmp'
+      :concat_basedir => '/tmp',
     }
   }
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -28,12 +28,16 @@ RSpec.configure do |c|
     begin
       # Install modules and dependencies from spec/fixtures/modules
       copy_fixture_modules_to( hosts )
+      server = only_host_with_role(hosts, 'server')
 
       # Generate and install PKI certificates on each SUT
       Dir.mktmpdir do |cert_dir|
-        run_fake_pki_ca_on( default, hosts, cert_dir )
+        run_fake_pki_ca_on(server, hosts, cert_dir )
         hosts.each{ |sut| copy_pki_to( sut, cert_dir, '/etc/pki/simp-testing' )}
       end
+
+      # add PKI keys
+      copy_keydist_to(server)
     rescue StandardError, ScriptError => e
       if ENV['PRY']
         require 'pry'; binding.pry


### PR DESCRIPTION
Users quite often will need to modify the /etc/shells content and it
would be nice for them to be able to do this without needing to
re-write the entire Array from scratch.

To solve this, we added a shells_default parameter as well as an empty
shells parameter which will be joined into the final file contents.

Additionally, we removed the entire securetty list so that securetty is
created as a blank file by default. This will prevent local root logins
by default as is current best practice.

If you include 'ANY_SHELL' in the securetty Array, then the
/etc/securetty file will be removed and allow root logins from any
source.

SIMP-2936 #close