### PR TITLE
(SIMP-3256) Allow regular TTY access for root by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2017 Liz Nemsick<lnemsick.simp@gmail.com> - 0.2.0
+- Populate /etc/securetty with tty0-tty4, by default. 
+
 * Wed Apr 26 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.1
 - Fixed useradd::libuser::defaults_crypt_style to only be a String of the
   allowed values

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
-* Mon Jun 12 2017 Liz Nemsick<lnemsick.simp@gmail.com> - 0.2.0
-- Populate /etc/securetty with tty0-tty4, by default. 
+* Mon Jun 12 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 0.2.0
+- Populate /etc/securetty with tty0-tty4, by default.
 
 * Wed Apr 26 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.1
 - Fixed useradd::libuser::defaults_crypt_style to only be a String of the

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,7 @@ class useradd (
   Boolean                                      $manage_passwd_perms   = true,
   Boolean                                      $manage_sysconfig_init = true,
   Boolean                                      $manage_useradd        = true,
-  Variant[Boolean,Array[String]]               $securetty             = [],
+  Variant[Boolean,Array[String]]               $securetty             = ['tty0', 'tty1', 'tty2', 'tty3', 'tty4'],
 
   Array[Stdlib::AbsolutePath]                  $shells_default        = [ '/bin/sh','/bin/bash','/sbin/nologin','/usr/bin/sh','/usr/bin/bash','/usr/sbin/nologin' ],
   Variant[Boolean,Array[Stdlib::AbsolutePath]] $shells                = []
@@ -70,12 +70,19 @@ class useradd (
       $_ensure_securetty = 'file'
     }
 
+    if $securetty == true {
+      $_securetty = []
+    }
+    else {
+      $_securetty = $securetty
+    }
+
     file { '/etc/securetty':
       ensure  => $_ensure_securetty,
       owner   => 'root',
       group   => 'root',
       mode    => '0400',
-      content => join($securetty,"\n")
+      content => join($_securetty,"\n")
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,9 +20,10 @@
 #
 # @param securetty
 #   List of ttys available to log into
+#   Defaults to ['tty0', 'tty1', 'tty2', 'tty3', 'tty4']
 #
-#   * Set to false to disable management
-#   * If the Array is empty (default) then root will not be able to log into
+#   * If set to false, management of /etc/securetty will be disabled
+#   * If set to true or an empty array, root will not be able to log into
 #     any local device
 #   * If the string 'ANY_SHELL' is found in the Array, then the
 #     ``/etc/securetty`` file will be removed and root will be able to login

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-useradd",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing settings regarding users and user creation",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,24 +8,31 @@ describe 'useradd' do
           facts
         end
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_class('useradd') }
+        context 'with default parameters' do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('useradd') }
 
-        it { is_expected.to create_file('/etc/securetty').with_content(<<-EOF.gsub(/^\s+/,'').strip
-        EOF
-        ) }
+          it { is_expected.to create_file('/etc/securetty').with_content(<<-EOF.gsub(/^\s+/,'').strip
+            tty0
+            tty1
+            tty2
+            tty3
+            tty4
+          EOF
+          ) }
 
-        it { is_expected.to create_file('/etc/shells').with_content(<<-EOF.gsub(/^\s+/,'').strip
-          /bin/sh
-          /bin/bash
-          /sbin/nologin
-          /usr/bin/sh
-          /usr/bin/bash
-          /usr/sbin/nologin
-        EOF
-        ) }
+          it { is_expected.to create_file('/etc/shells').with_content(<<-EOF.gsub(/^\s+/,'').strip
+            /bin/sh
+            /bin/bash
+            /sbin/nologin
+            /usr/bin/sh
+            /usr/bin/bash
+            /usr/sbin/nologin
+          EOF
+          ) }
+        end
 
-        context 'when adding a securetty entry' do
+        context 'when setting a securetty entry' do
           let(:params){{
             :securetty => ['console']
           }}
@@ -64,6 +71,13 @@ describe 'useradd' do
         context 'with shells => false' do
           let(:params) {{ :shells => false }}
           it { is_expected.not_to create_file('/etc/shells') }
+        end
+
+        context 'with securetty => true' do
+          let(:params) {{ :securetty => true }}
+          it { is_expected.to create_file('/etc/securetty').with_content(<<-EOF.gsub(/^\s+/,'').strip
+          EOF
+          ) }
         end
 
         context 'with securetty => false' do


### PR DESCRIPTION
Enable tty0-tty4 in /etc/securetty.
Note:  Will move to data in modules when the module is expanded
to other OSs, as the implementation may need to be specialized for
each new OS/OS family.