### PR TITLE
(SIMP-6103) Replace OBE validate_umask() with Simplib::Umask

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ variables:
 #-----------------------------------------------------------------------
 
 .pup_4: &pup_4
-  image: 'ruby:2.4'
+  image: 'ruby:2.1'
   variables:
     PUPPET_VERSION: '~> 4.0'
     MATRIX_RUBY_VERSION: '2.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.2.3
+- Use Simplib::Umask data type in lieu of validate_umask(),
+  a deprecated simplib Puppet 3 function.
+
 * Fri Aug 24 2018 Nick Miller <nick.miller@onyxpoint.com> - 0.2.2
 - Add support for Puppet 5 and OEL
 - Update badges in README.md

--- a/manifests/login_defs.pp
+++ b/manifests/login_defs.pp
@@ -134,7 +134,7 @@ class useradd::login_defs (
   Boolean                                 $syslog_sg_enab        = true,
   Boolean                                 $syslog_su_enab        = true,
   Optional[String]                        $ttygroup              = undef,
-  Optional[String]                        $ttyperm               = undef,
+  Optional[Simplib::Umask]                $ttyperm               = undef,
   Optional[Stdlib::AbsolutePath]          $ttytype_file          = undef,
   Integer[0]                              $uid_min               = simplib::lookup('simp_options::uid::min', { 'default_value' => pick(fact('login_defs.uid_min'), 1000 ) }),
   Integer[1]                              $uid_max               = simplib::lookup('simp_options::uid::max', { 'default_value' => pick(fact('login_defs.uid_max'), 1000000 ) }),
@@ -143,8 +143,6 @@ class useradd::login_defs (
   Optional[Stdlib::AbsolutePath]          $userdel_cmd           = undef,
   Boolean                                 $usergroups_enab       = true
 ) {
-
-  if $ttyperm { validate_umask($ttyperm) }
 
   file { '/etc/login.defs':
     owner   => 'root',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-useradd",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing settings regarding users and user creation",
   "license": "Apache-2.0",


### PR DESCRIPTION
Use Simplib::Umask data type in lieu of validate_umask(),
a deprecated simplib Puppet 3 function.

SIMP-6103 #comment pupmod-simp-useradd