### PR TITLE
(SIMP-6880) Support systemd for rescue shell

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,12 @@
 fixtures:
   repositories:
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
-    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     simplib: https://github.com/simp/pupmod-simp-simplib.git
+    systemd:
+      repo: https://github.com/simp/puppet-systemd
+      branch: simp-master
     disa_stig-el7-baseline:
       repo: https://github.com/simp/inspec-profile-disa_stig-el7
       branch:  master

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Mar 23 2020 Trevor Vaughan <tvaughan@onyxpont.com> - 0.4.1
+- Add explicit support for setting the rescue/emergency shell on systemd systems.
+
 * Thu Jan 09 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 0.4.0
 - Add EL8 support
 - Update the upper bound of simp-simplib to < 5.0.0

--- a/manifests/sysconfig_init.pp
+++ b/manifests/sysconfig_init.pp
@@ -49,10 +49,17 @@ class useradd::sysconfig_init (
   if 'systemd' in $facts['init_systems'] {
     $_unit_file_content = @("END")
       [Service]
+      ExecStart=
       ExecStart=-/bin/sh -c "${single_user_login}; /usr/bin/systemctl --fail --no-block default"
       | END
 
-    systemd::unit_file { ['emergency.service', 'rescue.service']:
+    systemd::dropin_file{ 'emergency_exec.conf':
+      unit    => 'emergency.service',
+      content => $_unit_file_content
+    }
+
+    systemd::dropin_file{ 'rescue_exec.conf':
+      unit    => 'rescue.service',
       content => $_unit_file_content
     }
   }

--- a/manifests/sysconfig_init.pp
+++ b/manifests/sysconfig_init.pp
@@ -46,6 +46,17 @@ class useradd::sysconfig_init (
   Boolean              $autoswap          = false,
 ) {
 
+  if 'systemd' in $facts['init_systems'] {
+    $_unit_file_content = @("END")
+      [Service]
+      ExecStart=-/bin/sh -c "${single_user_login}; /usr/bin/systemctl --fail --no-block default"
+      | END
+
+    systemd::unit_file { ['emergency.service', 'rescue.service']:
+      content => $_unit_file_content
+    }
+  }
+
   file { '/etc/sysconfig/init':
     ensure  => 'file',
     owner   => 'root',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-useradd",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing settings regarding users and user creation",
   "license": "Apache-2.0",
@@ -28,6 +28,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.0 < 7.0.0"
+    },
+    {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 2.2.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/sysconfig_init_spec.rb
+++ b/spec/classes/sysconfig_init_spec.rb
@@ -27,6 +27,14 @@ AUTOSWAP=no
             EOF
           )
         }
+
+        if facts[:init_systems].include?('systemd')
+          it { is_expected.to contain_systemd__unit_file('emergency.service').with_content(/ExecStart=.+sulogin/) }
+          it { is_expected.to contain_systemd__unit_file('rescue.service').with_content(/ExecStart=.+sulogin/) }
+        else
+          it { is_expected.to_not contain_systemd__unit_file('emergency.service') }
+          it { is_expected.to_not contain_systemd__unit_file('rescue.service') }
+        end
       end
     end
   end

--- a/spec/classes/sysconfig_init_spec.rb
+++ b/spec/classes/sysconfig_init_spec.rb
@@ -29,8 +29,19 @@ AUTOSWAP=no
         }
 
         if facts[:init_systems].include?('systemd')
-          it { is_expected.to contain_systemd__unit_file('emergency.service').with_content(/ExecStart=.+sulogin/) }
-          it { is_expected.to contain_systemd__unit_file('rescue.service').with_content(/ExecStart=.+sulogin/) }
+          it { is_expected.to contain_systemd__dropin_file('emergency_exec.conf').with(
+            {
+              :unit    => 'emergency.service',
+              :content => /ExecStart=.+sulogin/
+            })
+          }
+
+          it { is_expected.to contain_systemd__dropin_file('rescue_exec.conf').with(
+            {
+              :unit    => 'rescue.service',
+              :content => /ExecStart=.+sulogin/
+            })
+          }
         else
           it { is_expected.to_not contain_systemd__unit_file('emergency.service') }
           it { is_expected.to_not contain_systemd__unit_file('rescue.service') }


### PR DESCRIPTION
Added support for systemd systems regarding setting the rescue/emergency
shell.

SIMP-6880 #close