### PR TITLE
(SIMP-7972) Inspec Test Failures

### DIFF
--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -11,7 +11,7 @@ HOSTS:
       - server
       - default
     platform:   el-8-x86_64
-    box:        generic/centos8
+    box:        centos/8
     hypervisor: <%= hypervisor %>
     yum_repos:
       chef-current:

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -11,7 +11,7 @@ HOSTS:
       - server
       - default
     platform:   el-8-x86_64
-    box:        centos/8
+    box:        generic/centos8
     hypervisor: <%= hypervisor %>
     yum_repos:
       chef-current:

--- a/spec/acceptance/suites/compliance/00_simp_profile_install_spec.rb
+++ b/spec/acceptance/suites/compliance/00_simp_profile_install_spec.rb
@@ -7,6 +7,12 @@ describe 'useradd STIG enforcement of simp profile' do
   let(:manifest) {
     <<-EOS
       include 'useradd'
+
+      # Settings for vagrant user
+      user { 'vagrant':
+        password_max_age => 60,
+        password_min_age => 1,
+      }
     EOS
   }
 

--- a/spec/fixtures/inspec_profiles/CentOS-7-disa_stig/controls/00_Control_Selector.rb
+++ b/spec/fixtures/inspec_profiles/CentOS-7-disa_stig/controls/00_Control_Selector.rb
@@ -1,5 +1,13 @@
-skips = {}
-overrides = []
+skips = {
+  'V-72001' => 'Skipping: Enforced via pupmod-simp-deferred_resources, not pupmod-simp-useradd.',
+  'V-72059' => 'Skipping: Vagrant base boxes do not have separate mount points defined for /home.',
+  'V-73167' => 'Skipping: Auditing controls are handled with pupmod-simp-auditd.',
+  'V-73173' => 'Skipping: Auditing controls are handled with pupmod-simp-auditd.'
+}
+overrides = [
+  'V-71927',
+  'V-72223'
+]
 subsystems = [ 'libuser_conf', 'user', '/etc/shadow', 'accounts', 'opasswd', 
 'home_dirs', 'user_profile', 'login_defs', 'gshadow' ]
 
@@ -28,11 +36,79 @@ require_controls 'disa_stig-el7-baseline' do
 
   ## Overrides ##
 
-# # USEFUL DESCRIPTION
-# control 'V-IDENTIFIER' do
-#   # Enhancement, leave this out if you just want to add a different test
-#   overrides << self.to_s
-#
-#   only_if { file('whatever').exist? }
-# end
+  # The current check does not account for `nfsnobody` user
+  # Filed SIMP-8333
+  control 'V-71927' do
+    overrides << self.to_s
+
+    shadow.users.each do |user|
+      # filtering on non-system accounts (uid >= 1000)
+      next unless user(user).uid >= 1000
+      next if user == 'nfsnobody'
+      describe shadow.users(user) do
+        its('min_days.first.to_i') { should cmp >= 1 }
+      end
+    end
+  end
+
+  # The current environment value check has a type mismatch
+  # Filed SIMP-8334
+  control 'V-72223' do
+    overrides << self.to_s
+
+    describe os_env('TMOUT') do
+      its('content') { should be <= "600" }
+    end
+
+    # Check if TMOUT is set in files (passive test)
+    files = ['/etc/bashrc'] + ['/etc/profile'] + command("find /etc/profile.d/*").stdout.split("\n")
+    latest_val = nil
+
+    files.each do |file|
+      readonly = false
+
+      # Skip to next file if TMOUT isn't present. Otherwise, get the last occurrence of TMOUT
+      next if (values = command("grep -Po '.*TMOUT.*' #{file}").stdout.split("\n")).empty?
+
+      # Loop through each TMOUT match and see if set TMOUT's value or makes it readonly
+      values.each_with_index { |value, index|
+
+        # Skip if starts with '#' - it represents a comment
+        next if !value.match(/^#/).nil?
+        # If readonly and value is inline - use that value
+        if !value.match(/^readonly[\s]+TMOUT[\s]*=[\s]*[\d]+$/).nil?
+          latest_val = value.match(/[\d]+/)[0].to_i
+          readonly = true
+          break
+        # If readonly, but, value is not inline - use the most recent value
+        elsif !value.match(/^readonly[\s]+([\w]+[\s]+)?TMOUT[\s]*([\s]+[\w]+[\s]*)*$/).nil?
+          # If the index is greater than 0, the configuraiton setting value.
+          # Otherwise, the configuration setting value is in the previous file
+          # and is already set in latest_val.
+          if index >= 1
+            latest_val = values[index - 1].match(/[\d]+/)[0].to_i
+          end
+          readonly = true
+          break
+        # Readonly is not set use the lastest value
+        else
+          latest_val = value.match(/[\d]+/)[0].to_i
+        end
+      }
+      # Readonly is set - stop processing files
+      break if readonly === true
+    end
+
+    if latest_val.nil?
+      describe "The TMOUT setting is configured" do
+        subject { !latest_val.nil? }
+        it { should be true }
+      end
+    else
+      describe"The TMOUT setting is configured properly" do
+        subject { latest_val }
+        it { should be <= 600 }
+      end
+    end
+  end
 end

--- a/spec/fixtures/inspec_profiles/CentOS-7-disa_stig/inspec.yml
+++ b/spec/fixtures/inspec_profiles/CentOS-7-disa_stig/inspec.yml
@@ -1,5 +1,5 @@
-name: EL7 Aide STIG
-title: Aide STIG for EL 7
+name: EL7 Useradd STIG
+title: Useradd STIG for EL 7
 supports:
   - os-family: redhat
 maintainer: SIMP Team


### PR DESCRIPTION
This set of changes addresses inspec testing issues for the module. Some tests
failed because of vagrant host differences, some tests were skipped as they are
covered by auditd module, not here, and there are currently two overrridden tests
that have issues within the primary inspec profile.

SIMP-7972 #close