### PR TITLE
(#69) Stopped managing /etc/security/opasswd in this module

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Feb 06 2024 Mike Riddle <mike@sicura.us> - 1.0.0
+- Stopped controlling /etc/security/opasswd through this module in favor of the SIMP PAM module
+
 * Mon Oct 23 2023 Steven Pritchard <steve@sicura.us> - 0.10.0
 - [puppetsync] Add EL9 support
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 3. [Usage - Configuration options and additional functionality](#usage)
 4. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 5. [Limitations - OS compatibility, etc.](#limitations)
-6. [Development - Guide for contributing to the module](#development)
+6. [Deprecations](#deprecations)
+7. [Development - Guide for contributing to the module](#development)
     * [Acceptance Tests - Beaker env variables](#acceptance-tests)
 
 
@@ -53,7 +54,6 @@ This module can configure:
   * `/etc/passwd-`
   * `/etc/profile.d/`
   * `/etc/securetty`
-  * `/etc/security/opasswd`
   * `/etc/shadow`
   * `/etc/shadow-`
   * `/etc/shells`
@@ -88,6 +88,9 @@ Each file can be managed or unmanaged individually, using the following variable
 
 Please refer to the [REFERENCE.md](./REFERENCE.md).
 
+## Deprecations
+
+As of version 1.0.0, this module will no longer manage `/etc/security/opasswd`. Version 7.0.0 and above of the [SIMP PAM Module](https://github.com/simp/pupmod-simp-pam) will allow users to specify the file they wish to store historical passwords in.
 
 ## Limitations
 

--- a/manifests/passwd.pp
+++ b/manifests/passwd.pp
@@ -3,17 +3,16 @@
 # author: SIMP Team <simp@simp-project.com>
 #
 class useradd::passwd {
-
   # CCE-26953-0
   # CCE-26856-5
   # CCE-26868-0
   file { [
-    '/etc/passwd',
-    '/etc/passwd-'
-  ]:
-    owner => 'root',
-    group => 'root',
-    mode  => '0644'
+      '/etc/passwd',
+      '/etc/passwd-',
+    ]:
+      owner => 'root',
+      group => 'root',
+      mode  => '0644',
   }
 
   # CCE-26947-2
@@ -22,33 +21,28 @@ class useradd::passwd {
   # CCE-27026-4
   # CCE-26975-3
   # CCE-26951-4
-  file { [
-    '/etc/shadow',
-    '/etc/shadow-',
-    '/etc/gshadow',
-    '/etc/gshadow-'
-  ]:
-    owner => 'root',
-    group => 'root',
-    mode  => '0000'
+  file {
+    [
+      '/etc/shadow',
+      '/etc/shadow-',
+      '/etc/gshadow',
+      '/etc/gshadow-',
+    ]:
+      owner => 'root',
+      group => 'root',
+      mode  => '0000',
   }
 
   # CCE-26822-7
   # CCE-26930-8
   # CCE-26954-8
-  file { [
-    '/etc/group',
-    '/etc/group-'
-  ]:
-    owner => 'root',
-    group => 'root',
-    mode  => '0644'
+  file {
+    [
+      '/etc/group',
+      '/etc/group-',
+    ]:
+      owner => 'root',
+      group => 'root',
+      mode  => '0644',
   }
-
-  file { '/etc/security/opasswd':
-    owner => 'root',
-    group => 'root',
-    mode  => '0600'
-  }
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-useradd",
-  "version": "0.10.0",
+  "version": "1.0.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing settings regarding users and user creation",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -25,7 +25,7 @@ servers.each do |server|
       }
 
       it 'should modify files to test management' do
-        on(server, 'chmod 777 /etc/passwd /etc/passwd- /etc/shadow /etc/shadow- /etc/gshadow /etc/gshadow- /etc/group /etc/group- /etc/security/opasswd')
+        on(server, 'chmod 777 /etc/passwd /etc/passwd- /etc/shadow /etc/shadow- /etc/gshadow /etc/gshadow- /etc/group /etc/group-')
         on(server, 'echo "management_test" | tee -a /etc/profile.d/simp.sh /etc/profile.d/simp.csh /etc/libuser.conf /etc/default/nss /etc/sysconfig/init /etc/login.defs /etc/default/useradd > /dev/null')
       end
 
@@ -110,11 +110,6 @@ servers.each do |server|
       it 'should not manage /etc/group-' do
         on(server, 'stat -c "%a %n" /etc/group-').output.strip
         expect(stdout).to match(%r(777 /etc/group-))
-      end
-
-      it 'should not manage /etc/security/opasswd' do
-        on(server, 'stat -c "%a %n" /etc/security/opasswd').output.strip
-        expect(stdout).to match(%r(777 /etc/security/opasswd))
       end
     end
 
@@ -203,11 +198,6 @@ servers.each do |server|
       it 'should manage /etc/group-' do
         on(server, 'stat -c "%a %n" /etc/group-').output.strip
         expect(stdout).to match(%r(644 /etc/group-))
-      end
-
-      it 'should manage /etc/security/opasswd' do
-        on(server, 'stat -c "%a %n" /etc/security/opasswd').output.strip
-        expect(stdout).to match(%r(600 /etc/security/opasswd))
       end
 
       it '/etc/securetty should be empty' do
@@ -324,7 +314,7 @@ servers.each do |server|
       end
 
       it 'should update new user accounts' do
-        on(server, 'chmod 777 /etc/passwd /etc/passwd- /etc/shadow /etc/shadow- /etc/gshadow /etc/gshadow- /etc/group /etc/group- /etc/security/opasswd')
+        on(server, 'chmod 777 /etc/passwd /etc/passwd- /etc/shadow /etc/shadow- /etc/gshadow /etc/gshadow- /etc/group /etc/group-')
         on(server, 'useradd defsuser -p password')
         on(server, 'chage -l defsuser').output.strip
         expect(stdout).to match(/^Minimum number of days between password change\s*:\s*0$/)

--- a/spec/classes/passwd_spec.rb
+++ b/spec/classes/passwd_spec.rb
@@ -29,11 +29,6 @@ describe 'useradd::passwd' do
         is_expected.to create_file('/etc/gshadow').with(expected_params)
         is_expected.to create_file('/etc/gshadow-').with(expected_params)
       }
-      it { is_expected.to create_file('/etc/security/opasswd').with(
-        :owner => 'root',
-        :group => 'root',
-        :mode  => '0600'
-      ) }
 
     end
   end


### PR DESCRIPTION
The file will now be managed within the SIMP PAM module.

Fixes #69